### PR TITLE
Add FilePaths to the package list

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM julia:1.6.1 
 
 RUN apt-get update && apt-get install -y git
-RUN julia -e 'using Pkg;Pkg.add("CrystalInfoFramework"); Pkg.add("Lerche")'
+RUN julia -e 'using Pkg; Pkg.add("CrystalInfoFramework"); Pkg.add("Lerche"); Pkg.add("FilePaths")'
 
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
This PR adds the `FilePaths` to the package list. This will (probably) allow the action to be used in scenarios where the caching is not enabled (e.g. `TopoCif` repository).